### PR TITLE
fix for fish v3.0 and later

### DIFF
--- a/fish_title.fish
+++ b/fish_title.fish
@@ -3,7 +3,7 @@ function fish_title
     and echo "($_) "
     or echo '('(basename $VIRTUAL_ENV)') '
 
-    set -l git_dir (command git rev-parse --show-toplevel ^ /dev/null)
+    set -l git_dir (command git rev-parse --show-toplevel 2> /dev/null)
     and echo (echo (basename $git_dir)/(git rev-parse --show-prefix) | string trim --chars='/')
     or echo (prompt_pwd)
 end


### PR DESCRIPTION
Fixes: `fatal: not a git repository (or any of the parent directories): .git`

related to: https://github.com/oh-my-fish/oh-my-fish/issues/585#issuecomment-873640888